### PR TITLE
feature(cli): Add environment var support for `WEBHOOK_URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,15 @@ Options
 
 ## File Support
 
-- Images are attached as `{ attachment, name: "{name}.{ext}" }`
-  - PNG
-  - GIF
-  - JPG / JPEG
-- Structured files are sent as is
-  - JSON
-  - YAML / YML
-  - TXT / MD *both treated as markdown*
-- Templates
-  > While there is no support for template engines like nunjucks, ejs or liquid - with the intention to move to plugins, these could become plugins themselves. The theorised event hooks / listeners will reinforce the design by having them listen for certain files (native file handlers will be included as standard but follow the same internal design as plugins).
+| Extensions | Description |
+| --- | --- |
+| `.md` / `.txt` | Markdown `{ content }` |
+| `.json` / `.yml` / `.yaml` | Raw payload |
+| `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` | Image `{ attachment, name: "{name}.{ext}" }` |
+
+Raw files are expected to use a file option that may look like `{ path: "./path/to/file.go", raw: true }`, using payload structure of *Image*. While `raw` is not supported yet, it is planned to be added in the future.
+  
+> While there is no support for template engines like nunjucks, ejs or liquid - with the intention to move to plugins, these could become plugins themselves. The theorised event hooks / listeners will reinforce the design by having them listen for certain files (native file handlers will be included as standard but follow the same internal design as plugins).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A command line tool to help Community Managers keep their information channels updated.
 
-Notes on progress can be found on the [project board](https://github.com/TinkerStorm/channel-backup/projects/1) or on the [Discord channel](https://discord.gg/7k6uS7kw5k).
+Notes on progress can be found on the [project board](https://github.com/TinkerStorm/channel-backup/projects/1).
 
 I am aware this program does not follow the regular conventions of an interface, but I have done my best to ensure that it is *accessable* with regular scripts like you would use the terminal. *That said, I discourage it with upmost concern.* In theory, this can be applied to monorepo setups where multiple channels are setup with webhooks to keep their information up to date, all that would need to be done is run the command across all packages.
 
@@ -96,3 +96,10 @@ Options
 ## License
 
 This package uses the [MIT](LICENSE) license.
+
+---
+
+## Support & Share
+
+- If you use this package, we'd love to hear about how you use it.
+- If you need help or have a suggestion, open an issue or contact us on [Discord](https://discord.gg/7k6uS7kw5k).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Options
 - `$schema` - uses the schema stored at the primary branch to help build the configuration
   > Some properties may not exist here if they are added in plugins.
 - `webhook` - either a webhook uri as string or an object `{ id, token }`
+  > Alternatively, this can be omitted in favor of using an environment variable.
+  > At present, `dotenv` is not used to load the environment variables on .
 - `files` - An array of files which are sent through the webhook (can either be direct files or globs)
 - `authors` (optional, plugin) - A map of authors to avatars.
   > When using 'username' or 'embeds.*.author.name' in full payloads (yml, json), this map will be used if the related avatar or icon slot is not filled.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
+  "keywords": [
+    "discord"
+  ],
   "xo": {
     "rules": {
       "no-await-in-loop": "off",

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,14 +51,19 @@ const cli = meow(`
 
 	const cache = await loadFile(cli.flags.directory, 'cache.json')
 		.then(file => JSON.parse(file.toString()))
-		.catch(() => ({})); // allow file read to fail if it does not exist
+		.catch(() => ({})); // Allow file read to fail if it does not exist
 	// #endregion
 
+	if (!config.webhook) {
+		// eslint-disable-next-line node/prefer-global/process
+		config.webhook = process.env.WEBHOOK_URL;
+	}
+
 	if (typeof config.webhook === 'string') {
-		const [, id, token] = config.webhook.match(/^https?:\/\/discord\.com\/api\/webhooks\/([0-9]+)\/([A-Za-z0-9_-]+)/i);
+		const [, id, token] = config.webhook.match(/^https?:\/\/discord\.com\/api\/webhooks\/(\d+)\/([\w-]+)/i);
 		config.webhook = {id, token};
 	}
-	
+
 	const result = await sequence({
 		config,
 		cache: cache[config.webhook.id] || [],

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,9 @@ export async function sequence(options) {
 	const context = {
 		...options,
 		messages: [],
-		log: (msg, { force = false } = {}) => {
+		log: (message, {force = false} = {}) => {
 			if (options.verbose || force) {
-				console.log(msg);
+				console.log(message);
 			}
 		},
 	};
@@ -62,9 +62,10 @@ export async function sequence(options) {
 	}
 
 	const remainingMessages = context.cache.slice(context.messages.length);
-	if(remainingMessages.length > 0) {
+	if (remainingMessages.length > 0) {
 		await cleanup(context, remainingMessages);
 	}
+
 	return context;
 }
 

--- a/src/plugins/author-resolver.js
+++ b/src/plugins/author-resolver.js
@@ -8,7 +8,6 @@ export default function authorResolver(ctx, payload) {
 	const {authors} = ctx.config;
 
 	if (!authors) {
-		// ctx.log('plugin(author-resolver): No authors found.');
 		return payload;
 	}
 

--- a/src/steps/conditional/cleanup.js
+++ b/src/steps/conditional/cleanup.js
@@ -5,14 +5,14 @@ export default async function cleanup(context, messages = context.cache) {
 
 	context.log(`steps(cleanup) Removing ${messages.length} messages`);
 
-	while (messages.length > 0) { // array mutation, prevent duplicate method attempts
+	while (messages.length > 0) { // Array mutation, prevent duplicate method attempts
 		const message = messages.shift();
 
 		await delay(1000);
 		try {
 			await webhook.deleteMessage(message);
-		} catch (err) {
-			context.log(`fail:steps(cleanup) Failed to delete message: ${err}`,{force:true});
+		} catch (error) {
+			context.log(`fail:steps(cleanup) Failed to delete message: ${error}`, {force: true});
 		}
 	}
 }

--- a/src/steps/loop/handle-message.js
+++ b/src/steps/loop/handle-message.js
@@ -11,16 +11,12 @@ export default async function handleMessage(ctx, payload, path, index) {
 	const cacheID = ctx.cache[index];
 	const webhook = getWebhook(ctx);
 
-	let message;
-	if (ctx.mode === 'update' && cacheID) {
-		// Deep equal check is currently not supported
-		message = await webhook.editMessage(cacheID, payload);
-	} else {
-		message = await webhook.send(payload);
-	}
+	const message = await (ctx.mode === 'update' && cacheID
+		? webhook.editMessage(cacheID, payload)
+		: webhook.send(payload));
 
 	ctx.messages.push(message.id);
 	ctx.log(`steps(handle-message) '${path}' -> '${message.id}'`);
-	
+
 	await delay(1000);
 }


### PR DESCRIPTION
## Added

- CLI will now query the environment variables for `WEBHOOK_URL` if one does not exist in the selected configuration _and then continues to split it into id and token_.

---

I am aware that the package does not check if files exist, nor does it check for the webhook itself. Right now, it is expected that everything is where it should be before being run (however, I will seek to change this in the major rewrite).

_CI is expected to fail having invalid build matrix._